### PR TITLE
FEAT : CDE-108-controle-provider-sur-monographies-uniquement

### DIFF
--- a/src/main/java/fr/abes/kafkaconvergence/service/BestPpnService.java
+++ b/src/main/java/fr/abes/kafkaconvergence/service/BestPpnService.java
@@ -10,6 +10,7 @@ import fr.abes.kafkaconvergence.entity.basexml.notice.NoticeXml;
 import fr.abes.kafkaconvergence.entity.basexml.notice.SubField;
 import fr.abes.kafkaconvergence.exception.BestPpnException;
 import fr.abes.kafkaconvergence.exception.IllegalPpnException;
+import fr.abes.kafkaconvergence.utils.PUBLICATION_TYPE;
 import fr.abes.kafkaconvergence.utils.TYPE_SUPPORT;
 import fr.abes.kafkaconvergence.utils.Utils;
 import lombok.Data;
@@ -56,6 +57,8 @@ public class BestPpnService {
         Set<String> ppnPrintResultList = new HashSet<>();
 
         if (!kbart.getPublication_type().isEmpty()) {
+            provider = Objects.equals(kbart.getPublication_type(), PUBLICATION_TYPE.serial.toString()) ? "" : provider;
+            System.out.println(provider);
             if (!kbart.getOnline_identifier().isEmpty()) {
                 log.debug("paramètres en entrée : type : " + kbart.getPublication_type() + " / id : " + kbart.getOnline_identifier() + " / provider : " + provider);
                 feedPpnListFromOnline(kbart, provider, ppnElecResultList, ppnPrintResultList);

--- a/src/main/java/fr/abes/kafkaconvergence/service/BestPpnService.java
+++ b/src/main/java/fr/abes/kafkaconvergence/service/BestPpnService.java
@@ -57,8 +57,7 @@ public class BestPpnService {
         Set<String> ppnPrintResultList = new HashSet<>();
 
         if (!kbart.getPublication_type().isEmpty()) {
-            provider = Objects.equals(kbart.getPublication_type(), PUBLICATION_TYPE.serial.toString()) ? "" : provider;
-            System.out.println(provider);
+            provider = kbart.getPublication_type().equals(PUBLICATION_TYPE.serial.toString()) ? "" : provider;
             if (!kbart.getOnline_identifier().isEmpty()) {
                 log.debug("paramètres en entrée : type : " + kbart.getPublication_type() + " / id : " + kbart.getOnline_identifier() + " / provider : " + provider);
                 feedPpnListFromOnline(kbart, provider, ppnElecResultList, ppnPrintResultList);

--- a/src/test/java/fr/abes/kafkaconvergence/service/BestPpnServiceTest.java
+++ b/src/test/java/fr/abes/kafkaconvergence/service/BestPpnServiceTest.java
@@ -72,7 +72,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test with 1 elecFromOnline & 1 printFromOnline")
     void getBestPpnTest01() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create PpnWithTypeDto for elec
         PpnWithTypeDto ppnWithType1 = new PpnWithTypeDto();
         ppnWithType1.setPpn("100000001");
@@ -120,7 +120,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test with 1 elecFromOnline & 1 elecFromPrint")
     void getBestPpnTest02() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create PpnWithTypeDto for elec
         PpnWithTypeDto ppnWithType1 = new PpnWithTypeDto();
         ppnWithType1.setPpn("100000001");
@@ -173,7 +173,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test sum of scores")
     void getBestPpnTest03() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create PpnWithTypeDto for elec
         PpnWithTypeDto ppnWithType1 = new PpnWithTypeDto();
         ppnWithType1.setPpn("100000001");
@@ -226,7 +226,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test throw BestPpnException same score")
     void getBestPpnTest04() throws IOException, IllegalPpnException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create PpnWithTypeDto for elec
         PpnWithTypeDto ppnWithType1 = new PpnWithTypeDto();
         ppnWithType1.setPpn("100000001");
@@ -327,7 +327,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test printFromPrint & 2 printFromDat ")
     void getBestPpnTest06() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
 
         //  Create a List of PpnWithListDto for elec
         List<PpnWithTypeDto> ppnWithTypeDto = new ArrayList<>();
@@ -375,7 +375,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test with 1 elecFromOnline & 1 printFromOnline & titleUrl is null")
     void getBestPpnTest07() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create PpnWithTypeDto for elec
         PpnWithTypeDto ppnWithType1 = new PpnWithTypeDto();
         ppnWithType1.setPpn("100000001");
@@ -426,7 +426,7 @@ class BestPpnServiceTest {
     @Test
     @DisplayName("Test with 0 FromOnline & 1 elecFromPrint")
     void getBestPpnTest08() throws IllegalPpnException, IOException, BestPpnException, URISyntaxException {
-        String provider = "urlProvider";
+        String provider = "";
         //  Create a ResultWsSudocDto for elec
         ResultWsSudocDto resultElec = new ResultWsSudocDto();
         List<PpnWithTypeDto> ppnWithTypeDto = new ArrayList<>();


### PR DESCRIPTION
     - ajuster algorithme (CDE-113) de la méthode getBestPpn dans BestPpnService.java pour envoyer un provider uniquement sur des monographies.